### PR TITLE
Add support for tags with multiple words

### DIFF
--- a/bakerydemo/blog/models.py
+++ b/bakerydemo/blog/models.py
@@ -179,7 +179,7 @@ class BlogIndexPage(RoutablePageMixin, Page):
     # More information on RoutablePages is at
     # http://docs.wagtail.io/en/latest/reference/contrib/routablepage.html
     @route('^tags/$', name='tag_archive')
-    @route('^tags/(\w+)/$', name='tag_archive')
+    @route('^tags/([\w-]+)/$', name='tag_archive')
     def tag_archive(self, request, tag=None):
 
         try:


### PR DESCRIPTION
Fixes issue where `my-blog/tags/multi-word-tag` would result in a 404, even if there was a valid tag slug for `mult-word-tag`